### PR TITLE
Fix Caffe installation snippet

### DIFF
--- a/instructions/how-to-prepare-your-system.md
+++ b/instructions/how-to-prepare-your-system.md
@@ -197,6 +197,7 @@ $ cmake -DBLAS=Open ../
 $ make all
 $ make runtest
 $ make install
+$ cd ..
 $ ./scripts/download_model_binary.py models/bvlc_reference_caffenet
 $ ./data/ilsvrc12/get_ilsvrc_aux.sh
 ```


### PR DESCRIPTION
A `cd ..` is in order for the rest of the commands to work. Tried to avoid navigating in the filesystem but ../bla/download.py doesn't work as the python script assumes it is ran from the project root (and it fails to find other files).