### PR TITLE
Update smoke-test-cpp.sh

### DIFF
--- a/scripts/smoke-test-cpp.sh
+++ b/scripts/smoke-test-cpp.sh
@@ -83,7 +83,7 @@ fi
 if [ -f ${test_dir}/pre-test.sh ]; then
     tmp_dir=$(pwd)
     cd $test_dir
-    ./pre-test.sh
+    source pre-test.sh
     cd $tmp_dir
 fi
 
@@ -92,7 +92,7 @@ testrunner --verbose --suit $test_dir/test.xml
 if [ -f ${test_dir}/post-test.sh ]; then
     tmp_dir=$(pwd)
     cd $test_dir
-    ./post-test.sh
+    source post-test.sh
     cd $tmp_dir
 fi
 


### PR DESCRIPTION
Using `source` instead of directly calling the script.

The difference is highlighted in the documentation of  `bash` :
```
source filename [arguments]
Read and execute commands from filename in the current shell environment and return the exit status of the last command executed from filename. [...]
```
while directly executing the script, execute it in a child process, so that all environment variables are lost when the script returns.