### PR TITLE
Enable `fakeMotionControl` in YARP

### DIFF
--- a/dockerfiles/gitpod/Dockerfile
+++ b/dockerfiles/gitpod/Dockerfile
@@ -92,7 +92,7 @@ RUN git clone https://github.com/robotology/yarp.git --depth 1 && \
     cd yarp && mkdir build && cd build && \
     cmake .. \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-    -DENABLE_yarpmod_fakebot:BOOL=ON && \
+    -DENABLE_yarpmod_fakeMotionControl:BOOL=ON && \
     make install && \
     cd ../.. && rm -Rf yarp
 

--- a/dockerfiles/gitpod/Dockerfile
+++ b/dockerfiles/gitpod/Dockerfile
@@ -91,7 +91,8 @@ RUN git clone https://github.com/robotology/robot-testing-framework.git --depth 
 RUN git clone https://github.com/robotology/yarp.git --depth 1 && \
     cd yarp && mkdir build && cd build && \
     cmake .. \
-    -DCMAKE_BUILD_TYPE=$BUILD_TYPE && \
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DENABLE_yarpmod_fakebot:BOOL=ON && \
     make install && \
     cd ../.. && rm -Rf yarp
 


### PR DESCRIPTION
I'd need to enable this plugin for some tutorials.

I've seen that `robotology-superbuild` seems to be dealing with that by means of https://github.com/robotology/robotology-superbuild/blob/master/cmake/BuildYARP.cmake#L77.

@traversaro, am I correct? 